### PR TITLE
gl4_threads.c: fix nested function 'read' declared 'extern'

### DIFF
--- a/src/client/refresh/gl4/gl4_threads.c
+++ b/src/client/refresh/gl4/gl4_threads.c
@@ -36,6 +36,7 @@
 #include <windows.h>
 #else
 #include <pthread.h>
+#include <unistd.h>
 #endif
 
 static unsigned GL4_NumHWThreads(void) {
@@ -49,7 +50,6 @@ static unsigned GL4_NumHWThreads(void) {
     if (n > GL4_MAX_THREADS) n = GL4_MAX_THREADS;
     return n;
 #else
-    #include <unistd.h>
     long n = sysconf(_SC_NPROCESSORS_ONLN);
     unsigned u = (n > 0) ? (unsigned)n : 1u;
     if (u > GL4_MAX_THREADS) u = GL4_MAX_THREADS;


### PR DESCRIPTION
| /home/flk/poky/build/tmp/work/corei7-64-poky-linux/yquake2-gl4-renderer/1.0.9/recipe-sysroot/usr/include/bits/unistd.h:26:1: error: nested function 'read' declared 'extern'
|    26 | read (int __fd, __fortify_clang_overload_arg0 (void *, ,__buf), size_t __nbytes)
|       | ^~~~

Signed-off-by: Markus Volk <f_l_k@t-online.de>